### PR TITLE
Require both EnableReconcilers and EnableReconcilersV2 in PlaylistConfig to instantiate reconciler

### DIFF
--- a/apps/playlist/pkg/app/app.go
+++ b/apps/playlist/pkg/app/app.go
@@ -18,6 +18,7 @@ import (
 
 type PlaylistConfig struct {
 	EnableReconcilers bool
+	EnableReconcilersV2 bool
 }
 
 func getPatchClient(restConfig rest.Config, playlistKind resource.Kind) (operator.PatchClient, error) {
@@ -32,7 +33,7 @@ func New(cfg app.Config) (app.App, error) {
 	)
 
 	playlistConfig, ok := cfg.SpecificConfig.(*PlaylistConfig)
-	if ok && playlistConfig.EnableReconcilers {
+	if ok && playlistConfig.EnableReconcilers && playlistConfig.EnableReconcilersV2 {
 		patchClient, err := getPatchClient(cfg.KubeConfig, playlistv0alpha1.PlaylistKind())
 		if err != nil {
 			klog.ErrorS(err, "Error getting patch client for use with opinionated reconciler")


### PR DESCRIPTION
This pull request updates the logic in the Playlist app such that the instantiation of a reconciler now requires both EnableReconcilers and EnableReconcilersV2 fields in PlaylistConfig to be true, instead of just EnableReconcilers. Additionally, the PlaylistConfig struct is extended with the new EnableReconcilersV2 boolean flag. The change is isolated to the app.go file and modifies both the configuration struct and the conditional statement governing reconciler creation.

<!-- Summary by @propel-code-bot -->

---

Supplementing your description:

**Title:** Require Both EnableReconcilers and EnableReconcilersV2 to Instantiate Reconciler in PlaylistConfig

- **Code Quality:** Consider adding explanatory comments near the updated conditional logic to clarify why both flags must be enabled, as this may not be immediately clear to future maintainers.
- **Possible Issues:** This change may break existing setups that depended solely on the EnableReconcilers flag. Updating documentation and providing guidance on migration or config validation is recommended to prevent confusion.
- **Commit Quality:** The commit message could be improved. Use a message like 'Require both EnableReconcilers and EnableReconcilersV2 for reconciler creation in PlaylistConfig' for clearer historical traceability.
- **Review Difficulty:** This is an EASY review as the changes are localized and clear.
- **PR Type:** Classified as a MINOR change.

<details>
<summary><strong>Code Quality Assessment</strong></summary>

**apps/playlist/pkg/app/app.go**: Change is clear and localized, but lacks explanatory comments on the dual-flag logic as suggested by reviewers.


</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• This is a breaking change for users who previously relied on EnableReconcilers alone.
• Lack of documentation/comments could cause confusion for future maintainers.
• Unclear migration path for current users (e.g., config validation or upgrade documentation missing).

</details>

---
*This summary was automatically generated by @propel-code-bot*