### PR TITLE
Update app.go: Add EnableReconcilersV2 field to PlaylistConfig struct

### DIFF
--- a/apps/playlist/pkg/app/app.go
+++ b/apps/playlist/pkg/app/app.go
@@ -18,6 +18,7 @@ import (
 
 type PlaylistConfig struct {
 	EnableReconcilers bool
+	EnableReconcilersV2 bool
 }
 
 func getPatchClient(restConfig rest.Config, playlistKind resource.Kind) (operator.PatchClient, error) {
@@ -32,7 +33,7 @@ func New(cfg app.Config) (app.App, error) {
 	)
 
 	playlistConfig, ok := cfg.SpecificConfig.(*PlaylistConfig)
-	if ok && playlistConfig.EnableReconcilers {
+	if ok && playlistConfig.EnableReconcilers && playlistConfig.EnableReconcilersV2 {
 		patchClient, err := getPatchClient(cfg.KubeConfig, playlistv0alpha1.PlaylistKind())
 		if err != nil {
 			klog.ErrorS(err, "Error getting patch client for use with opinionated reconciler")


### PR DESCRIPTION
<!-- Summary by @propel-code-bot -->

**Add V2 Reconciler Configuration Option**

This pull request adds a new configuration option `EnableReconcilersV2` to the `PlaylistConfig` struct in `app.go`. The change updates the condition in the `New` function to require both `EnableReconcilers` and `EnableReconcilersV2` to be true for the reconciler to be initialized. This modification allows for more granular control over the playlist reconciler initialization process.

<details>
<summary><strong>Code Quality Assessment</strong></summary>

**`app.go`**: The changes maintain the existing code style and structure. The addition of the new field and the update to the condition are straightforward and easy to understand.


</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• The new configuration option might introduce backward compatibility issues if not properly documented
• The additional condition in the `New` function might make the function more complex and harder to maintain

</details>

---
*This summary was automatically generated by @propel-code-bot*