### PR TITLE
Add flex layout to metrics tab for better responsiveness

### DIFF
--- a/public/app/features/panel/partials/metrics_tab.html
+++ b/public/app/features/panel/partials/metrics_tab.html
@@ -25,28 +25,35 @@
 	</div>
 </div>
 
-<query-troubleshooter panel-ctrl="ctrl.panelCtrl"></query-troubleshooter>
+<div class="metrics_tab_flex_container">
+	
+	<div class="metrics_tab_flex_container--item-1">
+		<collapse-box title="Data Source: {{ctrl.dsSegment.value}}">
+			<collapse-box-body>
 
-<collapse-box title="Data Source: {{ctrl.dsSegment.value}}">
-	<collapse-box-body>
-
-		<div class="gf-form-group">
-			<div class="gf-form-inline">
-				<div class="gf-form">
-					<label class="gf-form-label">
-						Panel Data Source
-					</label>
-					<metric-segment segment="ctrl.dsSegment" get-options="ctrl.getOptions(true)" on-change="ctrl.datasourceChanged()"></metric-segment>
+				<div class="gf-form-group">
+					<div class="gf-form-inline">
+						<div class="gf-form">
+							<label class="gf-form-label">
+								Panel Data Source
+							</label>
+							<metric-segment segment="ctrl.dsSegment" get-options="ctrl.getOptions(true)" on-change="ctrl.datasourceChanged()"></metric-segment>
+						</div>
+					</div>
 				</div>
-			</div>
-		</div>
 
-		<rebuild-on-change property="ctrl.panel.datasource" show-null="true">
-			<plugin-component type="query-options-ctrl">
-			</plugin-component>
-		</rebuild-on-change>
+				<rebuild-on-change property="ctrl.panel.datasource" show-null="true">
+					<plugin-component type="query-options-ctrl">
+					</plugin-component>
+				</rebuild-on-change>
 
-	</collapse-box-body>
-</collapse-box>
+			</collapse-box-body>
+		</collapse-box>
+	</div>
 
+	<div class="metrics_tab_flex_container--item-2">
+		<query-troubleshooter panel-ctrl="ctrl.panelCtrl"></query-troubleshooter>
+	</div>
+
+</div>
 <div class="clearfix"></div>

--- a/public/app/features/panel/query_troubleshooter.ts
+++ b/public/app/features/panel/query_troubleshooter.ts
@@ -7,19 +7,19 @@ import {coreModule, JsonExplorer} from 'app/core/core';
 const template = `
 <collapse-box title="Query Troubleshooter" is-open="ctrl.isOpen" state-changed="ctrl.stateChanged()"
               ng-class="{'collapse-box--error': ctrl.hasError}">
-  <collapse-box-actions>
-    <a class="pointer" ng-click="ctrl.toggleExpand()" ng-hide="ctrl.allNodesExpanded">
-      <i class="fa fa-plus-square-o"></i> Expand All
-    </a>
-    <a class="pointer" ng-click="ctrl.toggleExpand()" ng-show="ctrl.allNodesExpanded">
-      <i class="fa fa-minus-square-o"></i> Collapse All
-    </a>
-    <a class="pointer" clipboard-button="ctrl.getClipboardText()"><i class="fa fa-clipboard"></i> Copy to Clipboard</a>
-  </collapse-box-actions>
-  <collapse-box-body>
-    <i class="fa fa-spinner fa-spin" ng-show="ctrl.isLoading"></i>
-    <div class="query-troubleshooter-json"></div>
-  </collapse-box-body>
+    <collapse-box-actions>
+      <a class="pointer" ng-click="ctrl.toggleExpand()" ng-hide="ctrl.allNodesExpanded">
+        <i class="fa fa-plus-square-o"></i> Expand All
+      </a>
+      <a class="pointer" ng-click="ctrl.toggleExpand()" ng-show="ctrl.allNodesExpanded">
+        <i class="fa fa-minus-square-o"></i> Collapse All
+      </a>
+      <a class="pointer" clipboard-button="ctrl.getClipboardText()"><i class="fa fa-clipboard"></i> Copy to Clipboard</a>
+    </collapse-box-actions>
+    <collapse-box-body>
+      <i class="fa fa-spinner fa-spin" ng-show="ctrl.isLoading"></i>
+      <div class="query-troubleshooter-json"></div>
+    </collapse-box-body>
 </collapse-box>
 `;
 

--- a/public/app/features/panel/query_troubleshooter.ts
+++ b/public/app/features/panel/query_troubleshooter.ts
@@ -7,19 +7,19 @@ import {coreModule, JsonExplorer} from 'app/core/core';
 const template = `
 <collapse-box title="Query Troubleshooter" is-open="ctrl.isOpen" state-changed="ctrl.stateChanged()"
               ng-class="{'collapse-box--error': ctrl.hasError}">
-    <collapse-box-actions>
-      <a class="pointer" ng-click="ctrl.toggleExpand()" ng-hide="ctrl.allNodesExpanded">
-        <i class="fa fa-plus-square-o"></i> Expand All
-      </a>
-      <a class="pointer" ng-click="ctrl.toggleExpand()" ng-show="ctrl.allNodesExpanded">
-        <i class="fa fa-minus-square-o"></i> Collapse All
-      </a>
-      <a class="pointer" clipboard-button="ctrl.getClipboardText()"><i class="fa fa-clipboard"></i> Copy to Clipboard</a>
-    </collapse-box-actions>
-    <collapse-box-body>
-      <i class="fa fa-spinner fa-spin" ng-show="ctrl.isLoading"></i>
-      <div class="query-troubleshooter-json"></div>
-    </collapse-box-body>
+  <collapse-box-actions>
+    <a class="pointer" ng-click="ctrl.toggleExpand()" ng-hide="ctrl.allNodesExpanded">
+      <i class="fa fa-plus-square-o"></i> Expand All
+    </a>
+    <a class="pointer" ng-click="ctrl.toggleExpand()" ng-show="ctrl.allNodesExpanded">
+      <i class="fa fa-minus-square-o"></i> Collapse All
+    </a>
+    <a class="pointer" clipboard-button="ctrl.getClipboardText()"><i class="fa fa-clipboard"></i> Copy to Clipboard</a>
+  </collapse-box-actions>
+  <collapse-box-body>
+    <i class="fa fa-spinner fa-spin" ng-show="ctrl.isLoading"></i>
+    <div class="query-troubleshooter-json"></div>
+  </collapse-box-body>
 </collapse-box>
 `;
 

--- a/public/sass/_grafana.scss
+++ b/public/sass/_grafana.scss
@@ -77,6 +77,7 @@
 @import "components/row.scss";
 @import "components/json_explorer.scss";
 @import "components/collapse_box.scss";
+@import "components/metrics_tab.scss";
 
 // PAGES
 @import "pages/login";

--- a/public/sass/_variables.dark.scss
+++ b/public/sass/_variables.dark.scss
@@ -281,7 +281,7 @@ $footer-link-color:   $gray-1;
 $footer-link-hover:   $gray-4;
 
 // collapse box
-$collapse-box-body-border: $dark-5;
+$collapse-box-body-border: $dark-3;
 $collapse-box-body-error-border: $red;
 
 // json-explorer

--- a/public/sass/components/_metrics_tab.scss
+++ b/public/sass/components/_metrics_tab.scss
@@ -1,0 +1,19 @@
+.metrics_tab_flex_container {
+  display: block;
+  @include media-breakpoint-up(lg) {
+    display: flex;
+  }
+
+  &--item-1 {
+    flex-grow: 1;
+    @include media-breakpoint-up(md) {
+      flex-basis: 720px;
+      flex-shrink: 0;
+      flex-grow: 0;
+    }
+  }
+
+  &--item-2 {
+    flex-grow: 3;
+  }
+}


### PR DESCRIPTION
<!-- Summary by @propel-code-bot -->

**Query troubleshooting UI improvements**

This pull request modifies the query troubleshooting UI by restructuring the layout of the metrics tab. The changes involve moving the query troubleshooter component to a separate flex container item, adding new CSS classes for styling, and updating the corresponding SCSS files. The goal is to improve the visual organization and responsiveness of the query troubleshooting interface.

<details>
<summary><strong>Code Quality Assessment</strong></summary>

**public/app/features/panel/partials/metrics_tab.html**: The HTML changes are well-structured and follow the existing patterns.

**public/sass/components/_metrics_tab.scss**: The SCSS changes are clean and well-organized, using appropriate media queries for responsiveness.

**public/sass/_variables.dark.scss**: The variable changes are minimal and follow the existing dark theme conventions.

**public/sass/_grafana.scss**: The inclusion of the new SCSS file is appropriate and follows the existing import structure.


</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• Ensure that the flex layout does not cause any layout issues in older browsers that do not fully support flexbox
• Verify that the new styles do not introduce any accessibility issues
• Check that the collapse box functionality remains consistent with the updated styling

</details>

---
*This summary was automatically generated by @propel-code-bot*