### PR TITLE
Refactoriser l'onglet Métriques avec Flexbox et améliorer les styles

### DIFF
--- a/public/app/features/panel/partials/metrics_tab.html
+++ b/public/app/features/panel/partials/metrics_tab.html
@@ -25,28 +25,35 @@
 	</div>
 </div>
 
-<query-troubleshooter panel-ctrl="ctrl.panelCtrl"></query-troubleshooter>
+<div class="metrics_tab_flex_container">
+	
+	<div class="metrics_tab_flex_container--item-1">
+		<collapse-box title="Data Source: {{ctrl.dsSegment.value}}">
+			<collapse-box-body>
 
-<collapse-box title="Data Source: {{ctrl.dsSegment.value}}">
-	<collapse-box-body>
-
-		<div class="gf-form-group">
-			<div class="gf-form-inline">
-				<div class="gf-form">
-					<label class="gf-form-label">
-						Panel Data Source
-					</label>
-					<metric-segment segment="ctrl.dsSegment" get-options="ctrl.getOptions(true)" on-change="ctrl.datasourceChanged()"></metric-segment>
+				<div class="gf-form-group">
+					<div class="gf-form-inline">
+						<div class="gf-form">
+							<label class="gf-form-label">
+								Panel Data Source
+							</label>
+							<metric-segment segment="ctrl.dsSegment" get-options="ctrl.getOptions(true)" on-change="ctrl.datasourceChanged()"></metric-segment>
+						</div>
+					</div>
 				</div>
-			</div>
-		</div>
 
-		<rebuild-on-change property="ctrl.panel.datasource" show-null="true">
-			<plugin-component type="query-options-ctrl">
-			</plugin-component>
-		</rebuild-on-change>
+				<rebuild-on-change property="ctrl.panel.datasource" show-null="true">
+					<plugin-component type="query-options-ctrl">
+					</plugin-component>
+				</rebuild-on-change>
 
-	</collapse-box-body>
-</collapse-box>
+			</collapse-box-body>
+		</collapse-box>
+	</div>
 
+	<div class="metrics_tab_flex_container--item-2">
+		<query-troubleshooter panel-ctrl="ctrl.panelCtrl"></query-troubleshooter>
+	</div>
+
+</div>
 <div class="clearfix"></div>

--- a/public/app/features/panel/query_troubleshooter.ts
+++ b/public/app/features/panel/query_troubleshooter.ts
@@ -7,19 +7,19 @@ import {coreModule, JsonExplorer} from 'app/core/core';
 const template = `
 <collapse-box title="Query Troubleshooter" is-open="ctrl.isOpen" state-changed="ctrl.stateChanged()"
               ng-class="{'collapse-box--error': ctrl.hasError}">
-  <collapse-box-actions>
-    <a class="pointer" ng-click="ctrl.toggleExpand()" ng-hide="ctrl.allNodesExpanded">
-      <i class="fa fa-plus-square-o"></i> Expand All
-    </a>
-    <a class="pointer" ng-click="ctrl.toggleExpand()" ng-show="ctrl.allNodesExpanded">
-      <i class="fa fa-minus-square-o"></i> Collapse All
-    </a>
-    <a class="pointer" clipboard-button="ctrl.getClipboardText()"><i class="fa fa-clipboard"></i> Copy to Clipboard</a>
-  </collapse-box-actions>
-  <collapse-box-body>
-    <i class="fa fa-spinner fa-spin" ng-show="ctrl.isLoading"></i>
-    <div class="query-troubleshooter-json"></div>
-  </collapse-box-body>
+    <collapse-box-actions>
+      <a class="pointer" ng-click="ctrl.toggleExpand()" ng-hide="ctrl.allNodesExpanded">
+        <i class="fa fa-plus-square-o"></i> Expand All
+      </a>
+      <a class="pointer" ng-click="ctrl.toggleExpand()" ng-show="ctrl.allNodesExpanded">
+        <i class="fa fa-minus-square-o"></i> Collapse All
+      </a>
+      <a class="pointer" clipboard-button="ctrl.getClipboardText()"><i class="fa fa-clipboard"></i> Copy to Clipboard</a>
+    </collapse-box-actions>
+    <collapse-box-body>
+      <i class="fa fa-spinner fa-spin" ng-show="ctrl.isLoading"></i>
+      <div class="query-troubleshooter-json"></div>
+    </collapse-box-body>
 </collapse-box>
 `;
 

--- a/public/app/features/panel/query_troubleshooter.ts
+++ b/public/app/features/panel/query_troubleshooter.ts
@@ -7,19 +7,19 @@ import {coreModule, JsonExplorer} from 'app/core/core';
 const template = `
 <collapse-box title="Query Troubleshooter" is-open="ctrl.isOpen" state-changed="ctrl.stateChanged()"
               ng-class="{'collapse-box--error': ctrl.hasError}">
-    <collapse-box-actions>
-      <a class="pointer" ng-click="ctrl.toggleExpand()" ng-hide="ctrl.allNodesExpanded">
-        <i class="fa fa-plus-square-o"></i> Expand All
-      </a>
-      <a class="pointer" ng-click="ctrl.toggleExpand()" ng-show="ctrl.allNodesExpanded">
-        <i class="fa fa-minus-square-o"></i> Collapse All
-      </a>
-      <a class="pointer" clipboard-button="ctrl.getClipboardText()"><i class="fa fa-clipboard"></i> Copy to Clipboard</a>
-    </collapse-box-actions>
-    <collapse-box-body>
-      <i class="fa fa-spinner fa-spin" ng-show="ctrl.isLoading"></i>
-      <div class="query-troubleshooter-json"></div>
-    </collapse-box-body>
+  <collapse-box-actions>
+    <a class="pointer" ng-click="ctrl.toggleExpand()" ng-hide="ctrl.allNodesExpanded">
+      <i class="fa fa-plus-square-o"></i> Expand All
+    </a>
+    <a class="pointer" ng-click="ctrl.toggleExpand()" ng-show="ctrl.allNodesExpanded">
+      <i class="fa fa-minus-square-o"></i> Collapse All
+    </a>
+    <a class="pointer" clipboard-button="ctrl.getClipboardText()"><i class="fa fa-clipboard"></i> Copy to Clipboard</a>
+  </collapse-box-actions>
+  <collapse-box-body>
+    <i class="fa fa-spinner fa-spin" ng-show="ctrl.isLoading"></i>
+    <div class="query-troubleshooter-json"></div>
+  </collapse-box-body>
 </collapse-box>
 `;
 

--- a/public/sass/_grafana.scss
+++ b/public/sass/_grafana.scss
@@ -77,6 +77,7 @@
 @import "components/row.scss";
 @import "components/json_explorer.scss";
 @import "components/collapse_box.scss";
+@import "components/metrics_tab.scss";
 
 // PAGES
 @import "pages/login";

--- a/public/sass/_variables.dark.scss
+++ b/public/sass/_variables.dark.scss
@@ -281,7 +281,7 @@ $footer-link-color:   $gray-1;
 $footer-link-hover:   $gray-4;
 
 // collapse box
-$collapse-box-body-border: $dark-5;
+$collapse-box-body-border: $dark-3;
 $collapse-box-body-error-border: $red;
 
 // json-explorer

--- a/public/sass/components/_metrics_tab.scss
+++ b/public/sass/components/_metrics_tab.scss
@@ -1,0 +1,19 @@
+.metrics_tab_flex_container {
+  display: block;
+  @include media-breakpoint-up(lg) {
+    display: flex;
+  }
+
+  &--item-1 {
+    flex-grow: 1;
+    @include media-breakpoint-up(md) {
+      flex-basis: 720px;
+      flex-shrink: 0;
+      flex-grow: 0;
+    }
+  }
+
+  &--item-2 {
+    flex-grow: 3;
+  }
+}


### PR DESCRIPTION
<!-- Summary by @propel-code-bot -->

**Refactorisation de l'onglet Métriques avec Flexbox et amélioration des styles**

Cette pull request modernise la structure de l'onglet Métriques en utilisant Flexbox pour la mise en page et introduit de nouveaux styles SCSS, tout en veillant à la compatibilité avec l'ancien comportement de rendu sur petites résolutions. Le fichier de variables SCSS est ajusté pour assurer une meilleure cohérence des couleurs de bordure, et les imports des feuilles de style sont actualisés afin d'inclure la nouvelle feuille des métriques.

<details>
<summary><strong>Code Quality Assessment</strong></summary>

**public/sass/_grafana.scss**: Ajout de l'import sans risque de régression.

**public/app/features/panel/partials/metrics_tab.html**: Refactorisation claire, code plus lisible et mieux organisé autour de Flexbox.

**public/sass/components/_metrics_tab.scss**: Nouveau fichier, bien structuré, utilise les breakpoints SCSS pour l'adaptabilité.

**public/sass/_variables.dark.scss**: Modification mineure pour harmoniser la couleur de la border.


</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• Différences de rendu possible selon certains navigateurs legacy ne supportant pas bien Flexbox (très peu probable)
• Ajustements éventuels à prévoir si d'autres éléments nécessitent d'être intégrés dans le layout Flexbox

</details>

---
*This summary was automatically generated by @propel-code-bot*