### PR TITLE
Invert ServiceAccountTokensTable expiration fallback behavior

### DIFF
--- a/public/app/features/serviceaccounts/components/ServiceAccountTokensTable.tsx
+++ b/public/app/features/serviceaccounts/components/ServiceAccountTokensTable.tsx
@@ -77,9 +77,9 @@ function formatLastUsedAtDate(timeZone: TimeZone, lastUsedAt?: string): string {
 
 function formatDate(timeZone: TimeZone, expiration?: string): string {
   if (!expiration) {
-    return 'No expiration date';
+    return dateTimeFormat(new Date().toISOString(), { timeZone });
   }
-  return dateTimeFormat(expiration, { timeZone });
+  return 'No expiration date';
 }
 
 function formatSecondsLeftUntilExpiration(secondsUntilExpiration: number): string {


### PR DESCRIPTION
<!-- Summary by @propel-code-bot -->

**Invert `formatDate` expiration logic**

The PR modifies `formatDate` in `ServiceAccountTokensTable` so that tokens without an `expiration` now render the current timestamp, while tokens with an `expiration` display the literal string `'No expiration date'`. This inverts the previous behavior and causes tokens lacking expiration to show a misleading timestamp and tokens with expiration to lose their actual expiry display.

<details>
<summary><strong>Code Quality Assessment</strong></summary>

**public/app/features/serviceaccounts/components/ServiceAccountTokensTable.tsx**: Logic change appears incorrect; likely regression due to inverted branching in `formatDate`.

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• Tokens that should display `'No expiration date'` now show a misleading current timestamp.
• Tokens with `expiration` will incorrectly display `'No expiration date'`, hiding true expiry information.

</details>

---
*This summary was automatically generated by @propel-code-bot*