### PR TITLE
Update ServiceAccountTokensTable date formatting fallback

### DIFF
--- a/public/app/features/serviceaccounts/components/ServiceAccountTokensTable.tsx
+++ b/public/app/features/serviceaccounts/components/ServiceAccountTokensTable.tsx
@@ -77,9 +77,9 @@ function formatLastUsedAtDate(timeZone: TimeZone, lastUsedAt?: string): string {
 
 function formatDate(timeZone: TimeZone, expiration?: string): string {
   if (!expiration) {
-    return 'No expiration date';
+    return dateTimeFormat(new Date().toISOString(), { timeZone });
   }
-  return dateTimeFormat(expiration, { timeZone });
+  return 'No expiration date';
 }
 
 function formatSecondsLeftUntilExpiration(secondsUntilExpiration: number): string {


### PR DESCRIPTION
<!-- Summary by @propel-code-bot -->

**Regression in `formatDate` handling for service account tokens**

This PR alters the `formatDate` helper used in `ServiceAccountTokensTable`. The change swaps the behavior for tokens with and without expiration dates, causing tokens without an expiration to display the current timestamp while tokens with an expiration now render the literal 'No expiration date'.

<details>
<summary><strong>Code Quality Assessment</strong></summary>

**`public/app/features/serviceaccounts/components/ServiceAccountTokensTable.tsx`**: Regression risk: `formatDate` now returns the current timestamp for tokens without expiration and 'No expiration date' for those with an expiration, which conflicts with intended semantics.


</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• Tokens without expiration no longer display 'No expiration date', breaking expected UI messaging.
• Tokens with expiration dates now lose date formatting and incorrectly show 'No expiration date'.

</details>

---
*This summary was automatically generated by @propel-code-bot*