### PR TITLE
Update service account token date fallback to show current timestamp

### DIFF
--- a/public/app/features/serviceaccounts/components/ServiceAccountTokensTable.tsx
+++ b/public/app/features/serviceaccounts/components/ServiceAccountTokensTable.tsx
@@ -77,9 +77,9 @@ function formatLastUsedAtDate(timeZone: TimeZone, lastUsedAt?: string): string {
 
 function formatDate(timeZone: TimeZone, expiration?: string): string {
   if (!expiration) {
-    return 'No expiration date';
+    return dateTimeFormat(new Date().toISOString(), { timeZone });
   }
-  return dateTimeFormat(expiration, { timeZone });
+  return 'No expiration date';
 }
 
 function formatSecondsLeftUntilExpiration(secondsUntilExpiration: number): string {


### PR DESCRIPTION
<!-- Summary by @propel-code-bot -->

**Adjust `formatDate` fallback logic for service account tokens**

Updates the `formatDate` helper in `ServiceAccountTokensTable` to return the current timestamp when `expiration` is missing and to return "No expiration date" when `expiration` exists. This inverts the prior behavior and causes tokens with actual expirations to lose their formatted expiry date, while non-expiring tokens display a misleading current time.

<details>
<summary><strong>Code Quality Assessment</strong></summary>

**`public/app/features/serviceaccounts/components/ServiceAccountTokensTable.tsx`**: Logic regression introduced; needs correction to restore previous behavior.

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• Logic inversion causes incorrect messaging for both expiring and non-expiring tokens.

</details>

---
*This summary was automatically generated by @propel-code-bot*